### PR TITLE
Fix for adif being found randomly in the stream

### DIFF
--- a/src/org/mangui/hls/demux/AACDemuxer.as
+++ b/src/org/mangui/hls/demux/AACDemuxer.as
@@ -47,7 +47,7 @@ package org.mangui.hls.demux {
             var id3 : ID3 = new ID3(_data);
             // AAC should contain ID3 tag filled with a timestamp
             var frames : Vector.<AudioFrame> = AACDemuxer.getFrames(_data, _data.position);
-            var adif : ByteArray = getADIF(_data, 0);
+            var adif : ByteArray = getADIF(_data, id3.len);
             var adifTag : FLVTag = new FLVTag(FLVTag.AAC_HEADER, id3.timestamp, id3.timestamp, true);
             adifTag.push(adif, 0, adif.length);
             audioTags.push(adifTag);


### PR DESCRIPTION
When searching from position=0 and reading 2 bytes at the time, FFF1 is
not found directly after the id3 when the id3 has an odd number of
bytes. Search should start after id3 tag in order to be aligned
correctly with the two bytes syncword.
