### PR TITLE
FLEXPATH variable when building plus docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The plugin is compatible with the following players:
 
   - [Flowplayer](#flowplayer) 3.2.12
   - [OSMF 2.0](#strobe-media-playback-smp-and-other-osmf-based-players) based players (such as SMP and GrindPlayer)
-  - [Video.js][1] 4.6.2 (adaptation done here [https://github.com/mangui/video-js-swf][2])
+  - [Video.js][1] 4.6, 4.7, 4.8 (adaptation done here [https://github.com/mangui/video-js-swf][2])
   - [MediaElement.js][3] (adaptation done here [https://github.com/mangui/mediaelement][4], now integrated in official MediaElement.js release since 2.15.0)
 
 ## Features
@@ -164,6 +164,15 @@ swfobject.embedSWF('StrobeMediaPlayback.swf', 'player', 640, 360, '10.2', null, 
   name: 'player'
 });
 ```
+
+### Building
+---
+
+Run `FLEXPATH=/path/to/flex/sdk sh ./build.sh` inside the `build` directory
+
+`FLEXPATH` should point to your Flex SDK location (i.e. /opt/local/flex/4.6)
+
+After a successful build you will find fresh binaries in the `bin/debug` and `bin/release` directories
 
 ## License
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-#FLEXPATH=../../flex_sdk_4.6
-#FLEXPATH=../../apache_flex_sdk
-FLEXPATH=../../AIR_SDK
+if [ -z "$FLEXPATH" ]; then
+  echo "Usage FLEXPATH=/path/to/flex/sdk sh ./build.sh"
+  exit
+fi
 
 OPT_DEBUG="-use-network=false \
     -optimize=true \
@@ -25,7 +26,6 @@ $FLEXPATH/bin/compc \
     -output ../bin/release/flashls.swc \
     -target-player="10.1"
 
-
 echo "Compiling bin/release/flashlsChromeless.swf"
 $FLEXPATH/bin/mxmlc ../src/org/mangui/chromeless/ChromelessPlayer.as \
     -source-path ../src \
@@ -47,7 +47,6 @@ $FLEXPATH/bin/mxmlc ../src/org/mangui/chromeless/ChromelessPlayer.as \
     -default-size 480 270 \
     -default-background-color=0x000000
 ./add-opt-in.py ../bin/debug/flashlsChromeless.swf
-
 
 #echo "Compiling flashlsBasic.swf"
 #$FLEXPATH/bin/mxmlc ../src/org/mangui/basic/Player.as \
@@ -96,7 +95,6 @@ $FLEXPATH/bin/mxmlc ../src/org/mangui/osmf/plugins/HLSDynamicPlugin.as \
     -target-player="10.1" #-compiler.verbose-stacktraces=true -link-report=../test/osmf/link-report.xml
 ./add-opt-in.py ../bin/debug/flashlsOSMF.swf
 
-
 echo "Compiling bin/release/flashlsOSMF.swc"
 $FLEXPATH/bin/compc -include-sources ../src/org/mangui/osmf \
     -output ../bin/release/flashlsOSMF.swc \
@@ -116,5 +114,4 @@ $FLEXPATH/bin/compc -include-sources ../src/org/mangui/osmf \
     -target-player="10.1" \
     -debug=false \
     -external-library-path+=../lib/osmf
-
 


### PR DESCRIPTION
Just a micro change to make FLEXPATH a variable when building and
making life a bit easier (with building docs included) and update docs
support for video.js 4.6 to 4.8
