### PR TITLE
fix ID3 timestamp 33bit handling

### DIFF
--- a/src/org/mangui/hls/demux/ID3.as
+++ b/src/org/mangui/hls/demux/ID3.as
@@ -77,9 +77,12 @@ package org.mangui.hls.demux {
                         // skip null character (string end) + 3 first bytes
                         data.position += 4;
                         // timestamp is 33 bit expressed as a big-endian eight-octet number, with the upper 31 bits set to zero.
-                        var pts_33_bit : Number = data.readUnsignedByte() & 0x1;
+                        var pts_33_bit : int = data.readUnsignedByte() & 0x1;
                         hasTimestamp = true;
-                        timestamp = (data.readUnsignedInt() / 90) << pts_33_bit;
+                        timestamp = (data.readUnsignedInt() / 90);
+                        if (pts_33_bit) {
+                            timestamp   += 47721858.84; // 2^32 / 90
+                        }
                         CONFIG::LOGGING {
                         Log.debug("ID3 timestamp found:" + timestamp);
                         }


### PR DESCRIPTION
Hi.
I found a strange behavior when seeking player using flashlsFlowPlayer.swf.
My stream chunks has a timestamp that 33bit turn on.
and timestamp value became doubled.
