### PR TITLE
Single char segment name fails to parse.

### DIFF
--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -143,8 +143,9 @@
 
             while (i < lines.length) {
                 var line : String = lines[i++];
-                // discard blank line, length could be 0 or 1 if DOS terminated line (CR/LF)
-                if (line.length <= 1) {
+
+                // discard blank line, length could be 0 or if DOS terminated line (CR/LF), only a CR char
+                if (line.length <= 0 || line.indexOf("\r") == 0) {
                     continue;
                 }
 


### PR DESCRIPTION
If the m3u8 manifest has only a single character:

#EXTM3U
#EXT-X-ALLOW-CACHE:NO
#EXT-X-TARGETDURATION:2
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-KEY:METHOD=AES-128,URI="keyfile.kbin"
#EXTINF:2,
0
#EXTINF:2,
1

Then it is not parsed and recognized as a segment.