### PR TITLE
Fix incorrect event name for `complete` event.

### DIFF
--- a/src/org/mangui/chromeless/ChromelessPlayer.as
+++ b/src/org/mangui/chromeless/ChromelessPlayer.as
@@ -143,7 +143,7 @@ package org.mangui.chromeless {
 
         /** Forward events from the framework. **/
         protected function _completeHandler(event : HLSEvent) : void {
-            _trigger("ready");
+            _trigger("complete");
         };
 
         protected function _errorHandler(event : HLSEvent) : void {


### PR DESCRIPTION
I've just spotted my last merge request had an incorrect event name in the Chromeless player that would cause the `complete` event to never fire.

I've fixed this up now, and it should be ready to merge.