### PR TITLE
Move `HLSSettings` import into logging block.

### DIFF
--- a/src/org/mangui/hls/demux/Nalu.as
+++ b/src/org/mangui/hls/demux/Nalu.as
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
  package org.mangui.hls.demux {
 
-    import org.mangui.hls.HLSSettings;
     import flash.utils.ByteArray;
     CONFIG::LOGGING {
+    import org.mangui.hls.HLSSettings;
     import org.mangui.hls.utils.Log;
     }
 


### PR DESCRIPTION
I noticed that this was breaking release builds on my machine with the error:

```
/Users/karl/Sites/flashls/src/org/mangui/hls/demux/Nalu.as(6): col: 26 Error: Definition org.mangui.hls:HLSSettings could not be found.

    import org.mangui.hls.HLSSettings;
```

Moving the import into the `CONFIG::LOGGING` block fixed it up.