### PR TITLE
Chromeless player now sends mouse and keyboard events to JavaScript

### DIFF
--- a/examples/chromeless/index.html
+++ b/examples/chromeless/index.html
@@ -603,6 +603,30 @@ var flashlsEvents = {
     }).split("\0");
 
     appendLog("id3 data " + id3DataDecoded);
+  },
+
+  click: function(event) {
+    appendLog('click');
+  },
+
+  dblclick: function(event) {
+    appendLog('double click');
+  },
+
+  mousedown: function(event) {
+    appendLog('mouse down');
+  },
+
+  mouseup: function(event) {
+    appendLog('mouse up');
+  },
+
+  keydown: function(event) {
+    appendLog('key down - key code: ' + event.keyCode + ' , char code: ' + event.charCode);
+  },
+
+  keyup: function(event) {
+    appendLog('key up - key code: ' + event.keyCode + ' , char code: ' + event.charCode);
   }
 };
 


### PR DESCRIPTION
We now send across the following events:
* `click`
* `dblclick`
* `mousedown`
* `mouseup`
* `keydown`
* `keyup`

The `keydown` and `keyup` events send the `keyCode` and `charCode`.

**Note**: This commit removes the click to enter and exit fullscreen functionality! Let me know if this isn't acceptable, and we can find a way of incorporating both of them. I'm looking to make a second merge request that adds the ability to show an image button that lets you enter and exit fullscreen mode.