### PR TITLE
Reset Max Level on Resize

### DIFF
--- a/src/org/mangui/hls/HLS.as
+++ b/src/org/mangui/hls/HLS.as
@@ -173,6 +173,8 @@
         /* set stage */
         public function set stage(stage : Stage) : void {
             _stage = stage;
+
+            this.dispatchEvent(new HLSEvent(HLSEvent.STAGE_SET));
         }
 
         /* get stage */

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -26,6 +26,17 @@ package org.mangui.hls {
          */
         public static var maxLevelCappingMode : String = HLSMaxLevelCappingMode.DOWNSCALE;
 
+        /**
+         * Resets the available levels when the stage has been resized to reflect the max based on the current dimensions.
+         *      true - levels will be updated when an Event.RESIZE is fired from the stage
+         *      false - levels will not be updated when an Event.RESIZE is fired from the stage
+         *
+         * Note: this is dependent on the capLevelToStage settings being set to true.
+         *
+         * Default is false
+         */
+        public static var refreshLevelsOnResize : Boolean = false;
+
         // // // // // ///////////////////////////////////
         //
         // org.mangui.hls.stream.HLSNetStream

--- a/src/org/mangui/hls/controller/AutoLevelController.as
+++ b/src/org/mangui/hls/controller/AutoLevelController.as
@@ -8,6 +8,8 @@
     import org.mangui.hls.model.Level;
     import org.mangui.hls.event.HLSEvent;
 
+    import flash.events.Event;
+
     CONFIG::LOGGING {
         import org.mangui.hls.utils.Log;
     }

--- a/src/org/mangui/hls/controller/AutoLevelController.as
+++ b/src/org/mangui/hls/controller/AutoLevelController.as
@@ -38,12 +38,17 @@
             _hls = hls;
             _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
+            _hls.addEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
         }
         ;
 
         public function dispose() : void {
             _hls.removeEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.removeEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
+
+            if (_hls.stage) {
+                _hls.stage.removeEventListener(Event.RESIZE, _resizeHandler);
+            }
         }
 
         private function _fragmentLoadedHandler(event : HLSEvent) : void {
@@ -101,6 +106,24 @@
         }
         ;
 
+        private function _stageSetHandler(event:HLSEvent) : void {
+            if (!HLSSettings.capLevelToStage) {
+                return;
+            }
+
+            if (!HLSSettings.refreshLevelsOnResize) {
+                return;
+            }
+
+            _hls.stage.addEventListener(Event.RESIZE, _resizeHandler);
+        }
+
+        private function _resizeHandler(event:Event) : void {
+            if (HLSSettings.capLevelToStage && HLSSettings.refreshLevelsOnResize) {
+                _maxUniqueLevels = _maxLevelsWithUniqueDimensions;
+            }
+        }
+
         public function getbestlevel(download_bandwidth : Number) : int {
             var max_level : int = _max_level;
             for (var i : int = max_level; i >= 0; i--) {
@@ -134,7 +157,13 @@
                 var maxLevelsCount : int = _maxUniqueLevels.length;
 
                 if (_hls.stage && maxLevelsCount) {
-                    var maxLevel : Level = this._maxUniqueLevels[0], maxLevelIdx : int = maxLevel.index, sWidth : Number = this._hls.stage.stageWidth, sHeight : Number = this._hls.stage.stageHeight, lWidth : int, lHeight : int, i : int;
+                    var maxLevel : Level = this._maxUniqueLevels[0],
+                        maxLevelIdx : int = maxLevel.index,
+                        sWidth : Number = this._hls.stage.stageWidth,
+                        sHeight : Number = this._hls.stage.stageHeight,
+                        lWidth : int,
+                        lHeight : int,
+                        i : int;
 
                     switch (HLSSettings.maxLevelCappingMode) {
                         case HLSMaxLevelCappingMode.UPSCALE:
@@ -208,11 +237,11 @@
                 }
                 switch_to_level = current_level + 1;
             }
-            
             /* to switch level down :
             rsft should be smaller than switch up condition,
             or the current level is greater than max level
-             */ else if ((current_level > max_level && current_level > 0) || (current_level > 0 && (sftm < 1 - _switchdown[current_level]))) {
+             */
+            else if ((current_level > max_level && current_level > 0) || (current_level > 0 && (sftm < 1 - _switchdown[current_level]))) {
                 CONFIG::LOGGING {
                     Log.debug("sftm < 1-_switchdown[current_level]=" + _switchdown[current_level]);
                 }

--- a/src/org/mangui/hls/event/HLSEvent.as
+++ b/src/org/mangui/hls/event/HLSEvent.as
@@ -10,9 +10,9 @@
     public class HLSEvent extends Event {
         /** Identifier for a manifest loading event, triggered after a call to hls.load(url) **/
         public static const MANIFEST_LOADING : String = "hlsEventManifestLoading";
-        /** Identifier for a manifest parsed event, 
+        /** Identifier for a manifest parsed event,
          * triggered after main manifest has been retrieved and parsed.
-         * hls playlist may not be playable yet, in case of adaptive streaming, start level playlist is not downloaded yet at that stage */ 
+         * hls playlist may not be playable yet, in case of adaptive streaming, start level playlist is not downloaded yet at that stage */
         public static const MANIFEST_PARSED : String = "hlsEventManifestParsed";
         /** Identifier for a manifest loaded event, when this event is received, main manifest and start level has been retrieved */
         public static const MANIFEST_LOADED : String = "hlsEventManifestLoaded";
@@ -44,7 +44,7 @@
         public static const TAGS_LOADED : String = "hlsEventTagsLoaded";
         /** Identifier when last fragment of playlist has been loaded **/
         public static const LAST_VOD_FRAGMENT_LOADED : String = "hlsEventLastFragmentLoaded";
-        
+
         /** Identifier for a playback error event. **/
         public static const ERROR : String = "hlsEventError";
 
@@ -60,6 +60,8 @@
         public static const PLAYLIST_DURATION_UPDATED : String = "hlsPlayListDurationUpdated";
         /** Identifier for a ID3 updated event **/
         public static const ID3_UPDATED : String = "hlsID3Updated";
+        /** Identifier for a Stage set event **/
+        public static const STAGE_SET : String = "hlsStageSet";
 
         /** The current url **/
         public var url : String;


### PR DESCRIPTION
Hi,

This adds a new option to `HLSSettings`, `refreshLevelsOnResize`. The goal of this is to reset the `_maxUniqueLevels` in the `AutoLevelController` and set a new `_level` in the `FragmentLoader` on a `Event.RESIZE` of the `stage` object in an `HLS` instance.

This option is also reliant on the `HLSSettings.capLevelToStage` being set to `true`.

I tried to change as little as possible with this update, but please let me know if you have any issues with it.

Thanks.