### PR TITLE
HLSEvent that lets us know when level switch is successful.

### DIFF
--- a/src/org/mangui/hls/HLS.as
+++ b/src/org/mangui/hls/HLS.as
@@ -126,7 +126,11 @@ package org.mangui.hls {
         public function get loadLevel() : int {
             return _level;
         };
-
+		
+		/** Return the quality level of last played fragment **/
+		public function get lastPlayedLevel() : int {
+			return _hlsNetStream.lastPlayedLevel;
+		};
         /*  instant quality level switch (-1 for automatic level selection) */
         public function set currentLevel(level : int) : void {
             _manual_level = level;
@@ -144,6 +148,11 @@ package org.mangui.hls {
         public function set loadLevel(level : int) : void {
             _manual_level = level;
         };
+		
+		/*  set quality level for last played fragment  */
+		public function set lastPlayedLevel(level : int) : void {
+			_hlsNetStream.lastPlayedLevel = level;
+		};
 
         /* check if we are in automatic level selection mode */
         public function get autoLevel() : Boolean {

--- a/src/org/mangui/hls/event/HLSEvent.as
+++ b/src/org/mangui/hls/event/HLSEvent.as
@@ -56,6 +56,8 @@ package org.mangui.hls.event {
         public static const PLAYLIST_DURATION_UPDATED : String = "hlsPlayListDurationUpdated";
         /** Identifier for a ID3 updated event **/
         public static const ID3_UPDATED : String = "hlsID3Updated";
+		/** Identifier for a Level switch event **/
+		public static const LEVEL_SWITCHED : String = "levelSwitched";
         /** The current url **/
         public var url : String;
         /** The current quality level. **/

--- a/src/org/mangui/hls/stream/HLSNetStream.as
+++ b/src/org/mangui/hls/stream/HLSNetStream.as
@@ -49,6 +49,8 @@ package org.mangui.hls.stream {
         private var _currentLevel : int;
         /** Netstream client proxy */
         private var _client : HLSNetStreamClient;
+	/** last played level */
+	private var _lastPlayedLevel : int;
 
         /** Create the buffer. **/
         public function HLSNetStream(connection : NetConnection, hls : HLS, streamBuffer : StreamBuffer) : void {
@@ -79,6 +81,12 @@ package org.mangui.hls.stream {
                     Log.debug("custom tag:" + tags[i]);
                 }
             }
+		if( _hls.lastPlayedLevel  && _hls.lastPlayedLevel != level)
+			{
+				_hls.dispatchEvent(new HLSEvent(HLSEvent.LEVEL_SWITCHED));
+			}
+			_hls.lastPlayedLevel = level;
+
             _hls.dispatchEvent(new HLSEvent(HLSEvent.FRAGMENT_PLAYING, new HLSPlayMetrics(level, seqnum, cc, duration, audio_only, program_date, width, height, tag_list)));
         }
 
@@ -161,7 +169,15 @@ package org.mangui.hls.stream {
         public function get currentLevel() : int {
             return _currentLevel;
         };
-
+	/** Return the last played fragment quality level **/
+	public function get lastPlayedLevel() : int {
+		 return _lastPlayedLevel ;
+	};
+		
+	/**  set quality level for last played fragment  **/
+	public function set lastPlayedLevel(level : int) : void {
+		_lastPlayedLevel = level;
+	};
         /** append tags to NetStream **/
         public function appendTags(tags : Vector.<FLVTag>) : void {
             if (_seekState == HLSSeekStates.SEEKING) {


### PR DESCRIPTION
Hi @mangui  , this pull request is corresponding to issue #302 .
Here before playing the fragment that is loaded, i am comparing whether we are playing the old level or a new level (that is loaded according to adaptive bit rate logic ),
If we are playing new level ,then we dispatch a HLSEvent.LEVEL_SWITCHED event before playing the fragment , which will let us know when exactly level switch is successful. 

Regards
Suhas