### PR TITLE
Reset Max Level On Resize

### DIFF
--- a/src/org/mangui/hls/HLS.as
+++ b/src/org/mangui/hls/HLS.as
@@ -233,6 +233,8 @@ package org.mangui.hls {
         /* set stage */
         public function set stage(stage : Stage) : void {
             _stage = stage;
+
+            this.dispatchEvent(new HLSEvent(HLSEvent.STAGE_SET));
         }
 
         /* get stage */

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -26,17 +26,6 @@ package org.mangui.hls {
          */
         public static var maxLevelCappingMode : String = HLSMaxLevelCappingMode.DOWNSCALE;
 
-        /**
-         * Resets the available levels when the stage has been resized to reflect the max based on the current dimensions.
-         *      true - levels will be updated when an Event.RESIZE is fired from the stage
-         *      false - levels will not be updated when an Event.RESIZE is fired from the stage
-         *
-         * Note: this is dependent on the capLevelToStage settings being set to true.
-         *
-         * Default is false
-         */
-        public static var refreshLevelsOnResize : Boolean = false;
-
         // // // // // // /////////////////////////////////
         //
         // org.mangui.hls.stream.HLSNetStream

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -25,6 +25,18 @@ package org.mangui.hls {
          * Default is HLSMaxLevelCappingMode.DOWNSCALE
          */
         public static var maxLevelCappingMode : String = HLSMaxLevelCappingMode.DOWNSCALE;
+
+        /**
+         * Resets the available levels when the stage has been resized to reflect the max based on the current dimensions.
+         *      true - levels will be updated when an Event.RESIZE is fired from the stage
+         *      false - levels will not be updated when an Event.RESIZE is fired from the stage
+         *
+         * Note: this is dependent on the capLevelToStage settings being set to true.
+         *
+         * Default is false
+         */
+        public static var refreshLevelsOnResize : Boolean = false;
+
         // // // // // // /////////////////////////////////
         //
         // org.mangui.hls.stream.HLSNetStream

--- a/src/org/mangui/hls/controller/LevelController.as
+++ b/src/org/mangui/hls/controller/LevelController.as
@@ -10,6 +10,8 @@ package org.mangui.hls.controller {
     import org.mangui.hls.HLSSettings;
     import org.mangui.hls.model.Level;
 
+    import flash.events.Event;
+
     CONFIG::LOGGING {
         import org.mangui.hls.utils.Log;
     }
@@ -43,6 +45,7 @@ package org.mangui.hls.controller {
             _hls.addEventListener(HLSEvent.MANIFEST_PARSED, _manifestParsedHandler);
             _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
+            _hls.addEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
         }
         ;
 
@@ -50,6 +53,11 @@ package org.mangui.hls.controller {
             _hls.removeEventListener(HLSEvent.MANIFEST_PARSED, _manifestParsedHandler);
             _hls.removeEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.removeEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
+            _hls.removeEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
+
+            if (_hls.stage) {
+                _hls.stage.removeEventListener(Event.RESIZE, _resizeHandler);
+            }
         }
 
         private function _fragmentLoadedHandler(event : HLSEvent) : void {
@@ -115,6 +123,43 @@ package org.mangui.hls.controller {
         }
         ;
 
+        /**
+         * Handler for when stage is set on HLS instance.
+         *
+         * @param event : HLSEvent
+         * @return void
+         */
+        private function _stageSetHandler(event:HLSEvent) : void {
+            if (!HLSSettings.capLevelToStage) {
+                return;
+            }
+
+            if (!HLSSettings.refreshLevelsOnResize) {
+                return;
+            }
+
+            _hls.stage.addEventListener(Event.RESIZE, _resizeHandler);
+        }
+
+        /**
+         * Stage resize handler. Resets the _maxUniqueLevels if the appropriate
+         * settings are set in the HLSSettings.
+         *
+         * @param event : Event
+         * @return void
+         */
+        private function _resizeHandler(event:Event) : void {
+            if (!HLSSettings.capLevelToStage) {
+                return;
+            }
+
+            if (!HLSSettings.refreshLevelsOnResize) {
+                return;
+            }
+
+            _maxUniqueLevels = _maxLevelsWithUniqueDimensions;
+        }
+
         public function getbestlevel(downloadBandwidth : Number) : int {
             var max_level : int = _maxLevel;
             for (var i : int = max_level; i >= 0; i--) {
@@ -162,7 +207,13 @@ package org.mangui.hls.controller {
                 var maxLevelsCount : int = _maxUniqueLevels.length;
 
                 if (_hls.stage && maxLevelsCount) {
-                    var maxLevel : Level = this._maxUniqueLevels[0], maxLevelIdx : int = maxLevel.index, sWidth : Number = this._hls.stage.stageWidth, sHeight : Number = this._hls.stage.stageHeight, lWidth : int, lHeight : int, i : int;
+                    var maxLevel : Level = this._maxUniqueLevels[0],
+                        maxLevelIdx : int = maxLevel.index,
+                        sWidth : Number = this._hls.stage.stageWidth,
+                        sHeight : Number = this._hls.stage.stageHeight,
+                        lWidth : int,
+                        lHeight : int,
+                        i : int;
 
                     switch (HLSSettings.maxLevelCappingMode) {
                         case HLSMaxLevelCappingMode.UPSCALE:
@@ -240,7 +291,8 @@ package org.mangui.hls.controller {
             /* to switch level down :
             rsft should be smaller than switch up condition,
             or the current level is greater than max level
-             */ else if ((current_level > max_level && current_level > 0) || (current_level > 0 && (sftm < 1 - _switchdown[current_level]))) {
+             */
+            else if ((current_level > max_level && current_level > 0) || (current_level > 0 && (sftm < 1 - _switchdown[current_level]))) {
                 CONFIG::LOGGING {
                     Log.debug("sftm < 1-_switchdown[current_level]=" + _switchdown[current_level]);
                 }

--- a/src/org/mangui/hls/controller/LevelController.as
+++ b/src/org/mangui/hls/controller/LevelController.as
@@ -134,10 +134,6 @@ package org.mangui.hls.controller {
                 return;
             }
 
-            if (!HLSSettings.refreshLevelsOnResize) {
-                return;
-            }
-
             _hls.stage.addEventListener(Event.RESIZE, _resizeHandler);
         }
 
@@ -150,10 +146,6 @@ package org.mangui.hls.controller {
          */
         private function _resizeHandler(event:Event) : void {
             if (!HLSSettings.capLevelToStage) {
-                return;
-            }
-
-            if (!HLSSettings.refreshLevelsOnResize) {
                 return;
             }
 

--- a/src/org/mangui/hls/event/HLSEvent.as
+++ b/src/org/mangui/hls/event/HLSEvent.as
@@ -56,6 +56,9 @@ package org.mangui.hls.event {
         public static const PLAYLIST_DURATION_UPDATED : String = "hlsPlayListDurationUpdated";
         /** Identifier for a ID3 updated event **/
         public static const ID3_UPDATED : String = "hlsID3Updated";
+        /** Identifier for a Stage set event **/
+        public static const STAGE_SET : String = "hlsStageSet";
+
         /** The current url **/
         public var url : String;
         /** The current quality level. **/

--- a/src/org/mangui/hls/loader/FragmentLoader.as
+++ b/src/org/mangui/hls/loader/FragmentLoader.as
@@ -55,8 +55,6 @@ package org.mangui.hls.loader {
         private var _keymap : Object;
         /** Did the stream switch quality levels. **/
         private var _switchLevel : Boolean;
-        /** Did the stage resize. **/
-        private var _stageResized : Boolean;
         /** Did a discontinuity occurs in the stream **/
         private var _hasDiscontinuity : Boolean;
         /** boolean to track whether PTS analysis is ongoing or not */
@@ -106,7 +104,6 @@ package org.mangui.hls.loader {
             _streamBuffer = streamBuffer;
             _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
-            _hls.addEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
             _timer = new Timer(20, 0);
             _timer.addEventListener(TimerEvent.TIMER, _checkLoading);
             _loadingState = LOADING_STOPPED;
@@ -118,7 +115,6 @@ package org.mangui.hls.loader {
             stop();
             _hls.removeEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.removeEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
-            _hls.removeEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
             _loadingState = LOADING_STOPPED;
             _keymap = new Object();
         }
@@ -190,7 +186,7 @@ package org.mangui.hls.loader {
                         /* first fragment already loaded
                          * check if we need to load next fragment, do it only if buffer is NOT full
                          */
-                    } else if (HLSSettings.maxBufferLength == 0 || _hls.stream.bufferLength < HLSSettings.maxBufferLength || _stageResized) {
+                    } else if (HLSSettings.maxBufferLength == 0 || _hls.stream.bufferLength < HLSSettings.maxBufferLength) {
                         // select level for next fragment load
                         if (_hls.autoLevel && _levels.length > 1 ) {
                             // select level from heuristics (current level / last fragment duration / buffer length)
@@ -218,7 +214,6 @@ package org.mangui.hls.loader {
                             _levelNext = level;
                         } else {
                             _loadingState = _loadnextfragment(level, _fragPrevious);
-                            _stageResized = false;
                         }
                     }
                     break;
@@ -770,48 +765,6 @@ package org.mangui.hls.loader {
             // speed up loading of new fragment
             _timer.start();
         };
-
-        /**
-         * Stage set on HLS object handler. Add RESIZE listener if the proper
-         * settings are set in the HLSSettings.
-         *
-         * @param event : HLSEvent
-         * @return void
-         */
-        private function _stageSetHandler(event:HLSEvent) : void {
-            if (!HLSSettings.capLevelToStage) {
-                return;
-            }
-
-            if (!HLSSettings.refreshLevelsOnResize) {
-                return;
-            }
-
-            _hls.stage.addEventListener(Event.RESIZE, _resizeHandler);
-        }
-
-        /**
-         * Stage resize handler.
-         * Sets stageResized flag, sets the loading to LOADING_IDLE
-         * in order to update the _level used for new fragment loads, and
-         * restarts the _timer in the event it was stopped.
-         *
-         * @param event : Event
-         * @return void
-         */
-        private function _resizeHandler(event:Event) : void {
-            if (!HLSSettings.capLevelToStage) {
-                return;
-            }
-
-            if (!HLSSettings.refreshLevelsOnResize) {
-                return;
-            }
-
-            _stageResized = true;
-            _loadingState = LOADING_IDLE;
-            _timer.start();
-        }
 
         /** triggered by demux, it should return the audio track to be parsed */
         private function _fragParsingAudioSelectionHandler(audioTrackList : Vector.<AudioTrack>) : AudioTrack {

--- a/src/org/mangui/hls/loader/FragmentLoader.as
+++ b/src/org/mangui/hls/loader/FragmentLoader.as
@@ -809,7 +809,7 @@ package org.mangui.hls.loader {
             }
 
             _stageResized = true;
-            _loading_state = LOADING_IDLE;
+            _loadingState = LOADING_IDLE;
             _timer.start();
         }
 


### PR DESCRIPTION
Hi,

This adds a new option to `HLSSettings`, `refreshLevelsOnResize`. The goal of this is to reset the `_maxUniqueLevels` in the `AutoLevelController` and set a new `_level` in the `FragmentLoader` on a `Event.RESIZE` of the `stage` object in an `HLS` instance.

This option is also reliant on the `HLSSettings.capLevelToStage` being set to `true`.

I tried to change as little as possible with this update, but please let me know if you have any issues with it.

Thanks.

(Ok, this should be good. Finally!)
