### PR TITLE
Encode ID3Data using Base64 instead of Hex. (Javascript can call window.atob() to decode it.) Removed redundant semi-colons, to reduce warnings in IntelliJ. Generate DEBUG swf files for debugging in IntelliJ.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -5,7 +5,7 @@ if [ -z "$FLEXPATH" ]; then
 fi
 
 OPT_DEBUG="-use-network=false \
-    -optimize=true \
+    -compiler.debug \
     -library-path+=../lib/blooddy_crypto.swc \
     -define=CONFIG::LOGGING,true \
     -define=CONFIG::FLASH_11_1,true"

--- a/examples/chromeless/index.html
+++ b/examples/chromeless/index.html
@@ -66,6 +66,7 @@ var Y_USEHWDECODER = 3;
 <script type="text/javascript" src="../libs/canvas.js"></script>
 <script type="text/javascript" src="../libs/metrics.js"></script>
 <script type="text/javascript" src="../libs/jsonpack.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
@@ -527,7 +528,7 @@ var flashlsEvents = {
     document.getElementById('mediaInfo').rows[Y_AUDIOTRACKID].cells[X_AUDIOTRACKID].innerHTML = trackId;
   },
   id3Updated: function(ID3Data) {
-    var event = {time : new Date() - jsLoadDate, type : "ID3Data"};
+    var event = {time : new Date() - jsLoadDate, type : "ID3Data", id3data: atob(ID3Data)};
     events.video.push(event);
   },
   requestPlaylist: JSLoaderPlaylist.requestPlaylist.bind(JSLoaderPlaylist),

--- a/src/org/mangui/hls/stream/HLSNetStream.as
+++ b/src/org/mangui/hls/stream/HLSNetStream.as
@@ -11,7 +11,8 @@ package org.mangui.hls.stream {
     import org.mangui.hls.flv.FLVTag;
     import org.mangui.hls.HLS;
     import org.mangui.hls.HLSSettings;
-    import org.mangui.hls.utils.Hex;
+
+    import by.blooddy.crypto.Base64;
 
     import flash.events.Event;
     import flash.events.NetStatusEvent;
@@ -69,7 +70,7 @@ package org.mangui.hls.stream {
             _client.registerCallback("onHLSFragmentSkipped", onHLSFragmentSkipped);
             _client.registerCallback("onID3Data", onID3Data);
             super.client = _client;
-        };
+        }
 
         public function onHLSFragmentChange(level : int, seqnum : int, cc : int, duration : Number, audio_only : Boolean, program_date : Number, width : int, height : int, auto_level : Boolean, ... tags) : void {
             CONFIG::LOGGING {
@@ -96,10 +97,9 @@ package org.mangui.hls.stream {
 
         // function is called by SCRIPT in FLV
         public function onID3Data(data : ByteArray) : void {
-            // we dump the content as hex to get it to the Javascript in the browser.
-            // from lots of searching, we could use base64, but even then, the decode would
-            // not be native, so hex actually seems more efficient
-            var dump : String = Hex.fromArray(data);
+            // we dump the content as base64 to get it to the Javascript in the browser.
+            // The client can use window.atob() to decode the ID3Data.
+            var dump : String = Base64.encode(data);
             CONFIG::LOGGING {
                 Log.debug("id3:" + dump);
             }
@@ -168,22 +168,22 @@ package org.mangui.hls.stream {
                     }
                 }
             }
-        };
+        }
 
         /** Return the current playback state. **/
         public function get playbackState() : String {
             return _playbackState;
-        };
+        }
 
         /** Return the current seek state. **/
         public function get seekState() : String {
             return _seekState;
-        };
+        }
 
         /** Return the current playback quality level **/
         public function get currentLevel() : int {
             return _currentLevel;
-        };
+        }
 
         /** append tags to NetStream **/
         public function appendTags(tags : Vector.<FLVTag>) : void {
@@ -225,7 +225,7 @@ package org.mangui.hls.stream {
                 dispatchEvent(new NetStatusEvent(NetStatusEvent.NET_STATUS, false, false, {code:"NetStream.Seek.Notify", level:"status"}));
                 _setSeekState(HLSSeekStates.SEEKED);
             }
-        };
+        }
 
         /** Change playback state. **/
         private function _setPlaybackState(state : String) : void {
@@ -236,7 +236,7 @@ package org.mangui.hls.stream {
                 _playbackState = state;
                 _hls.dispatchEvent(new HLSEvent(HLSEvent.PLAYBACK_STATE, _playbackState));
             }
-        };
+        }
 
         /** Change seeking state. **/
         private function _setSeekState(state : String) : void {
@@ -247,7 +247,7 @@ package org.mangui.hls.stream {
                 _seekState = state;
                 _hls.dispatchEvent(new HLSEvent(HLSEvent.SEEK_STATE, _seekState));
             }
-        };
+        }
 
         /* also include skipped duration in get time() so that play position will match fragment position */
         override public function get time() : Number {
@@ -288,7 +288,7 @@ package org.mangui.hls.stream {
                 super.pause();
                 _setPlaybackState(HLSPlayStates.PAUSED_BUFFERING);
             }
-        };
+        }
 
         /** Resume playback. **/
         override public function resume() : void {
@@ -302,17 +302,17 @@ package org.mangui.hls.stream {
                 // dont resume NetStream here, it will be resumed by Timer. this avoids resuming playback while seeking is in progress
                 _setPlaybackState(HLSPlayStates.PLAYING_BUFFERING);
             }
-        };
+        }
 
         /** get Buffer Length  **/
         override public function get bufferLength() : Number {
             return netStreamBufferLength + _streamBuffer.bufferLength;
-        };
+        }
 
         /** get Back Buffer Length  **/
         override public function get backBufferLength() : Number {
             return _streamBuffer.backBufferLength;
-        };
+        }
 
         public function get netStreamBufferLength() : Number {
             if (_seekState == HLSSeekStates.SEEKING) {
@@ -320,7 +320,7 @@ package org.mangui.hls.stream {
             } else {
                 return super.bufferLength;
             }
-        };
+        }
 
         /** Start playing data in the buffer. **/
         override public function seek(position : Number) : void {
@@ -351,11 +351,11 @@ package org.mangui.hls.stream {
              */
             super.pause();
             _timer.start();
-        };
+        }
 
         public override function set client(client : Object) : void {
             _client.delegate = client;
-        };
+        }
 
         public override function get client() : Object {
             return _client.delegate;
@@ -371,7 +371,7 @@ package org.mangui.hls.stream {
             _timer.stop();
             _setPlaybackState(HLSPlayStates.IDLE);
             _setSeekState(HLSSeekStates.IDLE);
-        };
+        }
 
         public function dispose_() : void {
             close();


### PR DESCRIPTION
Encode ID3Data using Base64 instead of Hex.
(Javascript can call window.atob() to decode it.)
Removed redundant semi-colons, to reduce warnings in IntelliJ.
Generate DEBUG swf files for debugging in IntelliJ.