### PR TITLE
adds useWeakReference to all addEventListener calls

### DIFF
--- a/src/org/mangui/basic/Player.as
+++ b/src/org/mangui/basic/Player.as
@@ -21,7 +21,7 @@ package org.mangui.basic {
             video.y = 0;
             video.smoothing = true;
             video.attachNetStream(hls.stream);
-            hls.addEventListener(HLSEvent.MANIFEST_LOADED, manifestHandler);
+            hls.addEventListener(HLSEvent.MANIFEST_LOADED, manifestHandler, false, 0, true);
             hls.load("http://domain.com/hls/m1.m3u8");
         }
 

--- a/src/org/mangui/chromeless/ChromelessPlayer.as
+++ b/src/org/mangui/chromeless/ChromelessPlayer.as
@@ -129,8 +129,8 @@ package org.mangui.chromeless {
             stage.scaleMode = StageScaleMode.NO_SCALE;
             stage.align = StageAlign.TOP_LEFT;
             stage.fullScreenSourceRect = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
-            stage.addEventListener(StageVideoAvailabilityEvent.STAGE_VIDEO_AVAILABILITY, _onStageVideoState);
-            stage.addEventListener(Event.RESIZE, _onStageResize);
+            stage.addEventListener(StageVideoAvailabilityEvent.STAGE_VIDEO_AVAILABILITY, _onStageVideoState, false, 0, true);
+            stage.addEventListener(Event.RESIZE, _onStageResize, false, 0, true);
         }
 
         protected function _setupSheet() : void {
@@ -138,7 +138,7 @@ package org.mangui.chromeless {
             _sheet = new Sprite();
             _sheet.graphics.beginFill(0x000000, 0);
             _sheet.graphics.drawRect(0, 0, stage.stageWidth, stage.stageHeight);
-            _sheet.addEventListener(MouseEvent.CLICK, _clickHandler);
+            _sheet.addEventListener(MouseEvent.CLICK, _clickHandler, false, 0, true);
             _sheet.buttonMode = true;
             addChild(_sheet);
         }
@@ -492,32 +492,32 @@ package org.mangui.chromeless {
             var available : Boolean = (event.availability == StageVideoAvailability.AVAILABLE);
             _hls = new HLS();
             _hls.stage = stage;
-            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _completeHandler);
-            _hls.addEventListener(HLSEvent.ERROR, _errorHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
-            _hls.addEventListener(HLSEvent.AUDIO_LEVEL_LOADED, _audioLevelLoadedHandler);
-            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_PLAYING, _fragmentPlayingHandler);
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler);
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler);
-            _hls.addEventListener(HLSEvent.SEEK_STATE, _seekStateHandler);
-            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
-            _hls.addEventListener(HLSEvent.AUDIO_TRACKS_LIST_CHANGE, _audioTracksListChange);
-            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChange);
-            _hls.addEventListener(HLSEvent.ID3_UPDATED, _id3Updated);
-            _hls.addEventListener(HLSEvent.FPS_DROP, _fpsDropHandler);
-            _hls.addEventListener(HLSEvent.FPS_DROP_LEVEL_CAPPING, _fpsDropLevelCappingHandler);
-            _hls.addEventListener(HLSEvent.FPS_DROP_SMOOTH_LEVEL_SWITCH, _fpsDropSmoothLevelSwitchHandler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _completeHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.ERROR, _errorHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_LEVEL_LOADED, _audioLevelLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_PLAYING, _fragmentPlayingHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.SEEK_STATE, _seekStateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACKS_LIST_CHANGE, _audioTracksListChange, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChange, false, 0, true);
+            _hls.addEventListener(HLSEvent.ID3_UPDATED, _id3Updated, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP, _fpsDropHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP_LEVEL_CAPPING, _fpsDropLevelCappingHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP_SMOOTH_LEVEL_SWITCH, _fpsDropSmoothLevelSwitchHandler, false, 0, true);
 
             if (available && stage.stageVideos.length > 0) {
                 _stageVideo = stage.stageVideos[0];
-                _stageVideo.addEventListener(StageVideoEvent.RENDER_STATE, _onStageVideoStateChange)
+                _stageVideo.addEventListener(StageVideoEvent.RENDER_STATE, _onStageVideoStateChange, false, 0, true)
                 _stageVideo.viewPort = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
                 _stageVideo.attachNetStream(_hls.stream);
             } else {
                 _video = new Video(stage.stageWidth, stage.stageHeight);
-                _video.addEventListener(VideoEvent.RENDER_STATE, _onVideoStateChange);
+                _video.addEventListener(VideoEvent.RENDER_STATE, _onVideoStateChange, false, 0, true);
                 addChild(_video);
                 _video.smoothing = true;
                 _video.attachNetStream(_hls.stream);

--- a/src/org/mangui/flowplayer/HLSStreamProvider.as
+++ b/src/org/mangui/flowplayer/HLSStreamProvider.as
@@ -72,12 +72,12 @@ package org.mangui.flowplayer {
             _player = player;
             _hls = new HLS();
             _hls.stage = player.screen.getDisplayObject().stage;
-            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _completeHandler);
-            _hls.addEventListener(HLSEvent.ERROR, _errorHandler);
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler);
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler);
-            _hls.addEventListener(HLSEvent.ID3_UPDATED, _ID3Handler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _completeHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.ERROR, _errorHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.ID3_UPDATED, _ID3Handler, false, 0, true);
 
             var cfg : Object = _model.config;
             for (var object : String in cfg) {

--- a/src/org/mangui/hls/HLS.as
+++ b/src/org/mangui/hls/HLS.as
@@ -60,7 +60,7 @@ package org.mangui.hls {
             var connection : NetConnection = new NetConnection();
             connection.connect(null);
             _hlsNetStream = new HLSNetStream(connection, this, _streamBuffer);
-            this.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
+            this.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler, false, 0, true);
         };
 
         /** Forward internal errors. **/

--- a/src/org/mangui/hls/controller/AudioTrackController.as
+++ b/src/org/mangui/hls/controller/AudioTrackController.as
@@ -27,8 +27,8 @@ package org.mangui.hls.controller {
 
         public function AudioTrackController(hls : HLS) {
             _hls = hls;
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler, false, 0, true);
         }
 
         public function dispose() : void {

--- a/src/org/mangui/hls/controller/BufferThresholdController.as
+++ b/src/org/mangui/hls/controller/BufferThresholdController.as
@@ -22,9 +22,9 @@ package org.mangui.hls.controller {
         /** Create the loader. **/
         public function BufferThresholdController(hls : HLS) : void {
             _hls = hls;
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.TAGS_LOADED, _fragmentLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.TAGS_LOADED, _fragmentLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler, false, 0, true);
         };
 
         public function dispose() : void {

--- a/src/org/mangui/hls/controller/FPSController.as
+++ b/src/org/mangui/hls/controller/FPSController.as
@@ -38,8 +38,8 @@
           _lastTime = 0;
           /** Check that Flash Player version is sufficient (11.2 or above) to use throttling event **/
           if(_checkVersion() >= 11.2) {
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler);
-            _hls.addEventListener(HLSEvent.STAGE_SET, _stageSetHandler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _playbackStateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.STAGE_SET, _stageSetHandler, false, 0, true);
           }
       }
 
@@ -66,9 +66,9 @@
           Log.debug("FPSController:stage defined, listen to throttle event");
         }
         _timer = new Timer(HLSSettings.fpsDroppedMonitoringPeriod,0);
-        _timer.addEventListener(TimerEvent.TIMER, _checkFPS);
+        _timer.addEventListener(TimerEvent.TIMER, _checkFPS, false, 0, true);
         _timer.start();
-        _hls.stage.addEventListener(THROTTLE, onThrottle);
+        _hls.stage.addEventListener(THROTTLE, onThrottle, false, 0, true);
       }
 
       private function _playbackStateHandler(event : HLSEvent) : void {

--- a/src/org/mangui/hls/controller/LevelController.as
+++ b/src/org/mangui/hls/controller/LevelController.as
@@ -44,10 +44,10 @@ package org.mangui.hls.controller {
             _fpsController = new FPSController(hls);
             /* low priority listener, so that other listeners with default priority
                could seamlessly set hls.startLevel in their HLSEvent.MANIFEST_PARSED listener */
-            _hls.addEventListener(HLSEvent.MANIFEST_PARSED, _manifestParsedHandler, false, int.MIN_VALUE);
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOAD_EMERGENCY_ABORTED, _fragmentLoadedHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_PARSED, _manifestParsedHandler, false, int.MIN_VALUE, true);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOAD_EMERGENCY_ABORTED, _fragmentLoadedHandler, false, 0, true);
         }
         ;
 

--- a/src/org/mangui/hls/demux/TSDemuxer.as
+++ b/src/org/mangui/hls/demux/TSDemuxer.as
@@ -140,7 +140,7 @@ package org.mangui.hls.demux {
                 _readPosition = 0;
                 _totalBytes = 0;
                 _dataOffset = 0;
-                _timer.addEventListener(TimerEvent.TIMER, _parseTimer);
+                _timer.addEventListener(TimerEvent.TIMER, _parseTimer, false, 0, true);
             }
             _dataVector.push(data);
             _totalBytes += data.length;

--- a/src/org/mangui/hls/handler/StatsHandler.as
+++ b/src/org/mangui/hls/handler/StatsHandler.as
@@ -24,14 +24,14 @@
 
         public function StatsHandler(hls : HLS) {
             _hls = hls;
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_PLAYING,_fragmentPlayingHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_SKIPPED,_fragmentSkippedHandler);
-            _hls.addEventListener(HLSEvent.FRAGMENT_LOAD_EMERGENCY_ABORTED,_fragmentLoadEmergencyAbortedHandler);
-            _hls.addEventListener(HLSEvent.FPS_DROP, _fpsDropHandler);
-            _hls.addEventListener(HLSEvent.FPS_DROP_LEVEL_CAPPING, _fpsDropLevelCappingHandler);
-            _hls.addEventListener(HLSEvent.FPS_DROP_SMOOTH_LEVEL_SWITCH, _fpsDropSmoothLevelSwitchHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_PLAYING,_fragmentPlayingHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_SKIPPED,_fragmentSkippedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FRAGMENT_LOAD_EMERGENCY_ABORTED,_fragmentLoadEmergencyAbortedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP, _fpsDropHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP_LEVEL_CAPPING, _fpsDropLevelCappingHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.FPS_DROP_SMOOTH_LEVEL_SWITCH, _fpsDropSmoothLevelSwitchHandler, false, 0, true);
         }
 
         public function dispose() : void {

--- a/src/org/mangui/hls/loader/AltAudioFragmentLoader.as
+++ b/src/org/mangui/hls/loader/AltAudioFragmentLoader.as
@@ -85,7 +85,7 @@ package org.mangui.hls.loader {
             _hls = hls;
             _streamBuffer = streamBuffer;
             _timer = new Timer(20, 0);
-            _timer.addEventListener(TimerEvent.TIMER, _checkLoading);
+            _timer.addEventListener(TimerEvent.TIMER, _checkLoading, false, 0, true);
             _loadingState = LOADING_STOPPED;
             _keymap = new Object();
         };
@@ -190,7 +190,7 @@ package org.mangui.hls.loader {
             _fragmentFirstLoaded = false;
             _fragPrevious = null;
             _level = _hls.audioTracks[_hls.audioTrack].level;
-            _hls.addEventListener(HLSEvent.AUDIO_LEVEL_LOADED, _audioLevelLoadedHandler);
+            _hls.addEventListener(HLSEvent.AUDIO_LEVEL_LOADED, _audioLevelLoadedHandler, false, 0, true);
             _timer.start();
         }
 
@@ -574,16 +574,16 @@ package org.mangui.hls.loader {
             if (_fragstreamloader == null) {
                 var urlStreamClass : Class = _hls.URLstream as Class;
                 _fragstreamloader = (new urlStreamClass()) as URLStream;
-                _fragstreamloader.addEventListener(IOErrorEvent.IO_ERROR, _fragLoadErrorHandler);
-                _fragstreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _fragLoadErrorHandler);
-                _fragstreamloader.addEventListener(ProgressEvent.PROGRESS, _fragLoadProgressHandler);
-                _fragstreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _fragLoadHTTPStatusHandler);
-                _fragstreamloader.addEventListener(Event.COMPLETE, _fragLoadCompleteHandler);
+                _fragstreamloader.addEventListener(IOErrorEvent.IO_ERROR, _fragLoadErrorHandler, false, 0, true);
+                _fragstreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _fragLoadErrorHandler, false, 0, true);
+                _fragstreamloader.addEventListener(ProgressEvent.PROGRESS, _fragLoadProgressHandler, false, 0, true);
+                _fragstreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _fragLoadHTTPStatusHandler, false, 0, true);
+                _fragstreamloader.addEventListener(Event.COMPLETE, _fragLoadCompleteHandler, false, 0, true);
                 _keystreamloader = (new urlStreamClass()) as URLStream;
-                _keystreamloader.addEventListener(IOErrorEvent.IO_ERROR, _keyLoadErrorHandler);
-                _keystreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _keyLoadErrorHandler);
-                _keystreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _keyLoadHTTPStatusHandler);
-                _keystreamloader.addEventListener(Event.COMPLETE, _keyLoadCompleteHandler);
+                _keystreamloader.addEventListener(IOErrorEvent.IO_ERROR, _keyLoadErrorHandler, false, 0, true);
+                _keystreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _keyLoadErrorHandler, false, 0, true);
+                _keystreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _keyLoadHTTPStatusHandler, false, 0, true);
+                _keystreamloader.addEventListener(Event.COMPLETE, _keyLoadCompleteHandler, false, 0, true);
             }
             if (_hasDiscontinuity) {
                 _demux = null;

--- a/src/org/mangui/hls/loader/AltAudioLevelLoader.as
+++ b/src/org/mangui/hls/loader/AltAudioLevelLoader.as
@@ -45,8 +45,8 @@ package org.mangui.hls.loader {
         /** Setup the loader. **/
         public function AltAudioLevelLoader(hls : HLS) {
             _hls = hls;
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateHandler);
-            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackSwitchHandler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackSwitchHandler, false, 0, true);
         };
 
         public function dispose() : void {

--- a/src/org/mangui/hls/loader/FragmentLoader.as
+++ b/src/org/mangui/hls/loader/FragmentLoader.as
@@ -103,10 +103,10 @@ package org.mangui.hls.loader {
             _levelController = levelController;
             _audioTrackController = audioTrackController;
             _streamBuffer = streamBuffer;
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler, false, 0, true);
             _timer = new Timer(20, 0);
-            _timer.addEventListener(TimerEvent.TIMER, _checkLoading);
+            _timer.addEventListener(TimerEvent.TIMER, _checkLoading, false, 0, true);
             _loadingState = LOADING_STOPPED;
             _manifestJustLoaded = false;
             _keymap = new Object();
@@ -781,16 +781,16 @@ package org.mangui.hls.loader {
             if (_fragstreamloader == null) {
                 var urlStreamClass : Class = _hls.URLstream as Class;
                 _fragstreamloader = (new urlStreamClass()) as URLStream;
-                _fragstreamloader.addEventListener(IOErrorEvent.IO_ERROR, _fragLoadErrorHandler);
-                _fragstreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _fragLoadErrorHandler);
-                _fragstreamloader.addEventListener(ProgressEvent.PROGRESS, _fragLoadProgressHandler);
-                _fragstreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _fragLoadHTTPStatusHandler);
-                _fragstreamloader.addEventListener(Event.COMPLETE, _fragLoadCompleteHandler);
+                _fragstreamloader.addEventListener(IOErrorEvent.IO_ERROR, _fragLoadErrorHandler, false, 0, true);
+                _fragstreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _fragLoadErrorHandler, false, 0, true);
+                _fragstreamloader.addEventListener(ProgressEvent.PROGRESS, _fragLoadProgressHandler, false, 0, true);
+                _fragstreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _fragLoadHTTPStatusHandler, false, 0, true);
+                _fragstreamloader.addEventListener(Event.COMPLETE, _fragLoadCompleteHandler, false, 0, true);
                 _keystreamloader = (new urlStreamClass()) as URLStream;
-                _keystreamloader.addEventListener(IOErrorEvent.IO_ERROR, _keyLoadErrorHandler);
-                _keystreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _keyLoadErrorHandler);
-                _keystreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _keyLoadHTTPStatusHandler);
-                _keystreamloader.addEventListener(Event.COMPLETE, _keyLoadCompleteHandler);
+                _keystreamloader.addEventListener(IOErrorEvent.IO_ERROR, _keyLoadErrorHandler, false, 0, true);
+                _keystreamloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _keyLoadErrorHandler, false, 0, true);
+                _keystreamloader.addEventListener(HTTPStatusEvent.HTTP_STATUS, _keyLoadHTTPStatusHandler, false, 0, true);
+                _keystreamloader.addEventListener(Event.COMPLETE, _keyLoadCompleteHandler, false, 0, true);
             }
             if (_hasDiscontinuity || _switchLevel) {
                 _demux = null;

--- a/src/org/mangui/hls/loader/LevelLoader.as
+++ b/src/org/mangui/hls/loader/LevelLoader.as
@@ -63,8 +63,8 @@ package org.mangui.hls.loader {
         /** Setup the loader. **/
         public function LevelLoader(hls : HLS) {
             _hls = hls;
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateHandler);
-            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler, false, 0, true);
             _levels = new Vector.<Level>();
         }
 
@@ -141,10 +141,10 @@ package org.mangui.hls.loader {
                 //_urlloader = new URLLoader();
                 var urlLoaderClass : Class = _hls.URLloader as Class;
                 _urlloader = (new urlLoaderClass()) as URLLoader;
-                _urlloader.addEventListener(Event.COMPLETE, _loadCompleteHandler);
-                _urlloader.addEventListener(ProgressEvent.PROGRESS, _loadProgressHandler);
-                _urlloader.addEventListener(IOErrorEvent.IO_ERROR, _errorHandler);
-                _urlloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _errorHandler);
+                _urlloader.addEventListener(Event.COMPLETE, _loadCompleteHandler, false, 0, true);
+                _urlloader.addEventListener(ProgressEvent.PROGRESS, _loadProgressHandler, false, 0, true);
+                _urlloader.addEventListener(IOErrorEvent.IO_ERROR, _errorHandler, false, 0, true);
+                _urlloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, _errorHandler, false, 0, true);
             }
             _close();
             _closed = false;

--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -77,10 +77,10 @@ package org.mangui.hls.playlist {
             _index = index;
             var urlLoaderClass : Class = hls.URLloader as Class;
             _urlloader = (new urlLoaderClass()) as URLLoader;
-            _urlloader.addEventListener(Event.COMPLETE, _loadCompleteHandler);
-            _urlloader.addEventListener(ProgressEvent.PROGRESS, _loadProgressHandler);
-            _urlloader.addEventListener(IOErrorEvent.IO_ERROR, error);
-            _urlloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, error);
+            _urlloader.addEventListener(Event.COMPLETE, _loadCompleteHandler, false, 0, true);
+            _urlloader.addEventListener(ProgressEvent.PROGRESS, _loadProgressHandler, false, 0, true);
+            _urlloader.addEventListener(IOErrorEvent.IO_ERROR, error, false, 0, true);
+            _urlloader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, error, false, 0, true);
 
             if (flushLiveURLcache && type == HLSTypes.LIVE) {
                 /*

--- a/src/org/mangui/hls/stream/HLSNetStream.as
+++ b/src/org/mangui/hls/stream/HLSNetStream.as
@@ -77,7 +77,7 @@ package org.mangui.hls.stream {
             _playbackState = HLSPlayStates.IDLE;
             _seekState = HLSSeekStates.IDLE;
             _timer = new Timer(100, 0);
-            _timer.addEventListener(TimerEvent.TIMER, _checkBuffer);
+            _timer.addEventListener(TimerEvent.TIMER, _checkBuffer, false, 0, true);
             _client = new HLSNetStreamClient();
             _client.registerCallback("onHLSFragmentChange", onHLSFragmentChange);
             _client.registerCallback("onHLSFragmentSkipped", onHLSFragmentSkipped);

--- a/src/org/mangui/hls/stream/StreamBuffer.as
+++ b/src/org/mangui/hls/stream/StreamBuffer.as
@@ -85,12 +85,12 @@ package org.mangui.hls.stream {
             _altaudiofragmentLoader = new AltAudioFragmentLoader(hls, this);
             flushBuffer();
             _timer = new Timer(100, 0);
-            _timer.addEventListener(TimerEvent.TIMER, _checkBuffer);
-            _hls.addEventListener(HLSEvent.LIVE_LOADING_STALLED, _liveLoadingStalledHandler);
-            _hls.addEventListener(HLSEvent.PLAYLIST_DURATION_UPDATED, _playlistDurationUpdated);
-            _hls.addEventListener(HLSEvent.LAST_VOD_FRAGMENT_LOADED, _lastVODFragmentLoadedHandler);
-            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChange);
-            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete);
+            _timer.addEventListener(TimerEvent.TIMER, _checkBuffer, false, 0, true);
+            _hls.addEventListener(HLSEvent.LIVE_LOADING_STALLED, _liveLoadingStalledHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYLIST_DURATION_UPDATED, _playlistDurationUpdated, false, 0, true);
+            _hls.addEventListener(HLSEvent.LAST_VOD_FRAGMENT_LOADED, _lastVODFragmentLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChange, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete, false, 0, true);
         }
 
         public function dispose() : void {

--- a/src/org/mangui/hls/utils/AES.as
+++ b/src/org/mangui/hls/utils/AES.as
@@ -58,7 +58,7 @@
             _data.position = _writePosition;
             _data.writeBytes(data);
             if (_writePosition == 0) {
-                _displayObject.addEventListener(Event.ENTER_FRAME, _decryptTimer);
+                _displayObject.addEventListener(Event.ENTER_FRAME, _decryptTimer, false, 0, true);
             }
             _writePosition += data.length;
         }

--- a/src/org/mangui/hls/utils/JSURLStream.as
+++ b/src/org/mangui/hls/utils/JSURLStream.as
@@ -40,7 +40,7 @@ package org.mangui.hls.utils {
         protected static var _callbackName : String = 'JSLoaderFragment';
 
         public function JSURLStream() {
-            addEventListener(Event.OPEN, onOpen);
+            addEventListener(Event.OPEN, onOpen, false, 0, true);
             ExternalInterface.marshallExceptions = true;
             super();
 
@@ -125,7 +125,7 @@ package org.mangui.hls.utils {
             _readPosition = 0;
             _finalLength = len;
             _timer = new Timer(20, 0);
-            _timer.addEventListener(TimerEvent.TIMER, _decodeData);
+            _timer.addEventListener(TimerEvent.TIMER, _decodeData, false, 0, true);
             _timer.start();
             _base64Resource = base64Resource;
         }

--- a/src/org/mangui/osmf/plugins/HLSMediaElement.as
+++ b/src/org/mangui/osmf/plugins/HLSMediaElement.as
@@ -46,7 +46,7 @@
             _hls = hls;
             _defaultduration = duration;
             super(resource, new HLSNetLoader(hls));
-            _hls.addEventListener(HLSEvent.ERROR, _errorHandler);
+            _hls.addEventListener(HLSEvent.ERROR, _errorHandler, false, 0, true);
         }
 
         protected function createVideo() : Video {

--- a/src/org/mangui/osmf/plugins/loader/HLSLoadFromDocumentElement.as
+++ b/src/org/mangui/osmf/plugins/loader/HLSLoadFromDocumentElement.as
@@ -76,7 +76,7 @@ package org.mangui.osmf.plugins.loader {
             if (_resource != value && value != null) {
                 _resource = value;
                 loadTrait = new LoadFromDocumentLoadTrait(loader, resource);
-                loadTrait.addEventListener(LoadEvent.LOAD_STATE_CHANGE, onLoadStateChange, false, int.MAX_VALUE);
+                loadTrait.addEventListener(LoadEvent.LOAD_STATE_CHANGE, onLoadStateChange, false, int.MAX_VALUE, true);
 
                 if (super.getTrait(MediaTraitType.LOAD) != null) {
                     super.removeTrait(MediaTraitType.LOAD);
@@ -107,7 +107,7 @@ package org.mangui.osmf.plugins.loader {
                 // Set up a listener so that we can prevent the dispatch
                 // of a second LOADING event.
                 var proxiedLoadTrait : LoadTrait = loadTrait.mediaElement.getTrait(MediaTraitType.LOAD) as LoadTrait;
-                proxiedLoadTrait.addEventListener(LoadEvent.LOAD_STATE_CHANGE, onProxiedElementLoadStateChange, false, int.MAX_VALUE);
+                proxiedLoadTrait.addEventListener(LoadEvent.LOAD_STATE_CHANGE, onProxiedElementLoadStateChange, false, int.MAX_VALUE, true);
 
                 // Expose the proxied element.
                 proxiedElement = loadTrait.mediaElement;

--- a/src/org/mangui/osmf/plugins/loader/HLSLoaderBase.as
+++ b/src/org/mangui/osmf/plugins/loader/HLSLoaderBase.as
@@ -77,8 +77,8 @@
                 _hls = null;
             }
             _hls = new HLS();
-            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
-            _hls.addEventListener(HLSEvent.ERROR, _errorHandler);
+            _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.ERROR, _errorHandler, false, 0, true);
             /* load playlist */
             _hls.load(URLResource(loadTrait.resource).url);
         }

--- a/src/org/mangui/osmf/plugins/traits/HLSAlternativeAudioTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSAlternativeAudioTrait.as
@@ -31,8 +31,8 @@ package org.mangui.osmf.plugins.traits {
             _numAlternativeAudioStreams = _audioTrackList.length - 1;
             super(_numAlternativeAudioStreams);
             _media = media;
-            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChangedHandler);
-            _hls.addEventListener(HLSEvent.AUDIO_TRACKS_LIST_CHANGE, _audioTrackListChangedHandler);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACK_SWITCH, _audioTrackChangedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.AUDIO_TRACKS_LIST_CHANGE, _audioTrackListChangedHandler, false, 0, true);
         }
 
         override public function dispose() : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSBufferTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSBufferTrait.as
@@ -20,7 +20,7 @@
             }
             super();
             _hls = hls;
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateChangedHandler);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateChangedHandler, false, 0, true);
         }
 
         override public function dispose() : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSDisplayObjectTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSDisplayObjectTrait.as
@@ -28,7 +28,7 @@
             this.videoSurface = videoSurface as VideoSurface;
 
             if (this.videoSurface is VideoSurface)
-                this.videoSurface.addEventListener(Event.ADDED_TO_STAGE, onStage);
+                this.videoSurface.addEventListener(Event.ADDED_TO_STAGE, onStage, false, 0, true);
         }
 
         override public function dispose() : void {
@@ -42,7 +42,7 @@
         private function onStage(event : Event) : void {
             _hls.stage = event.target.stage as Stage;
             videoSurface.removeEventListener(Event.ADDED_TO_STAGE, onStage);
-            videoSurface.addEventListener(Event.ENTER_FRAME, onFrame);
+            videoSurface.addEventListener(Event.ENTER_FRAME, onFrame, false, 0, true);
         }
 
         private function onFrame(event : Event) : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSDynamicStreamTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSDynamicStreamTrait.as
@@ -19,7 +19,7 @@
             Log.debug("HLSDynamicStreamTrait()");
             }
             _hls = hls;
-            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
+            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler, false, 0, true);
             super(true, _hls.startLevel, hls.levels.length);
         }
 

--- a/src/org/mangui/osmf/plugins/traits/HLSNetStreamLoadTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSNetStreamLoadTrait.as
@@ -26,7 +26,7 @@
             _timeLoaded = 0;
             _timeTotal = duration;
             super.netStream = _hls.stream;
-            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler);
+            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler, false, 0, true);
         }
 
         override public function dispose() : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSPlayTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSPlayTrait.as
@@ -22,8 +22,8 @@
             }
             super();
             _hls = hls;
-            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateChangedHandler);
-            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete);
+            _hls.addEventListener(HLSEvent.PLAYBACK_STATE, _stateChangedHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete, false, 0, true);
         }
 
         override public function dispose() : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSSeekTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSSeekTrait.as
@@ -21,7 +21,7 @@
             }
             super(timeTrait);
             _hls = hls;
-            _hls.addEventListener(HLSEvent.SEEK_STATE, _stateChangedHandler);
+            _hls.addEventListener(HLSEvent.SEEK_STATE, _stateChangedHandler, false, 0, true);
         }
 
         override public function dispose() : void {

--- a/src/org/mangui/osmf/plugins/traits/HLSTimeTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSTimeTrait.as
@@ -20,8 +20,8 @@
             super(duration);
             setCurrentTime(0);
             _hls = hls;
-            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler);
-            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete);
+            _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler, false, 0, true);
+            _hls.addEventListener(HLSEvent.PLAYBACK_COMPLETE, _playbackComplete, false, 0, true);
         }
 
         override public function dispose() : void {


### PR DESCRIPTION
I was using 13 swf's on a screen at once with a barebone hls player in each. They all changed stream regularly and I found a small cumulative increase in memory usage which eventually would crash the flash player on the machine. It probably wouldn't affect most use cases, but using weak references in event listeners is good practice to avoid memory leaks and this certainly seemed to help the issue for me.
