### PR TITLE
Optionally route traffic through 3rd party proxy script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The plugin accepts several **optional** configuration options, such as:
   - `hls_caplevelonfpsdrop` (default true) : Limit levels usable in auto-quality when FPS drop is detected.i.e. if frame drop is detected on level 5, auto level will be capped to level 4. Note: this setting is ignored in manual mode so all the levels could be selected manually.
   - `hls_smoothautoswitchonfpsdrop` (default true) : force a smooth level switch Limit when FPS drop is detected in auto-quality. i.e. if frame drop is detected on level 5, it will trigger an auto quality level switch to level 4 for next fragment. Note: this setting is active only if capLevelonFPSDrop==true.
   - `hls_switchdownonlevelerror` (default true) : if level loading fails, and if in auto mode, and we are not on lowest level, don't report Level loading error straight-away, try to switch down first
+  - `hls_proxyUrl` (default empty string) : Defines url for proxying http requests through a proxy script on 3rd party server - such as [php-simple-proxy](https://github.com/cowboy/php-simple-proxy)  e.g. "http://xxx.xxx.xxx.xxx/simpleproxy.php?mode=native&url=". This is useful to play content where the source does not provide permission via crossdomain.xml. You should provide your own permissive crossdomain file on the server where the proxy script resides. All the traffic will be routed through this server via the proxy script so beware bandwidth costs! 
+    
 
 ## hls API
 hls API and events are described [here](API.md)

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -386,5 +386,16 @@ package org.mangui.hls {
          * Default is true
          */
         public static var logError : Boolean = true;
+		
+        /**
+         * proxyUrl
+         *
+         * Defines url for tunneling http requests through a proxy on another server - such as
+		 * https://github.com/cowboy/php-simple-proxy
+		 * e.g. "http://xxx.xxx.xxx.xxx/simpleproxy.php?mode=native&url="
+         *
+         * Default is an empty string
+         */
+        public static var proxyUrl : String = "";
     }
 }

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -386,13 +386,13 @@ package org.mangui.hls {
          * Default is true
          */
         public static var logError : Boolean = true;
-		
+        
         /**
          * proxyUrl
          *
          * Defines url for tunneling http requests through a proxy on another server - such as
-		 * https://github.com/cowboy/php-simple-proxy
-		 * e.g. "http://xxx.xxx.xxx.xxx/simpleproxy.php?mode=native&url="
+         * https://github.com/cowboy/php-simple-proxy
+         * e.g. "http://xxx.xxx.xxx.xxx/simpleproxy.php?mode=native&url="
          *
          * Default is an empty string
          */

--- a/src/org/mangui/hls/HLSSettings.as
+++ b/src/org/mangui/hls/HLSSettings.as
@@ -397,5 +397,14 @@ package org.mangui.hls {
          * Default is an empty string
          */
         public static var proxyUrl : String = "";
+        
+         /**
+         * useProxyForFragments
+         *
+         * Sometimes the proxy isn't required past the first playlist file, so disable it here.
+         *
+         * Default is true
+         */
+        static public var useProxyForFragments:Boolean = true;
     }
 }

--- a/src/org/mangui/hls/loader/LevelLoader.as
+++ b/src/org/mangui/hls/loader/LevelLoader.as
@@ -160,7 +160,7 @@ package org.mangui.hls.loader {
 
         /** Load the manifest file. **/
         public function load(url : String) : void {
-			if(HLSSettings.proxyUrl) url = HLSSettings.proxyUrl + escape(url)
+            if(HLSSettings.proxyUrl) url = HLSSettings.proxyUrl + escape(url)
             if(!_urlloader) {
                 //_urlloader = new URLLoader();
                 var urlLoaderClass : Class = _hls.URLloader as Class;

--- a/src/org/mangui/hls/loader/LevelLoader.as
+++ b/src/org/mangui/hls/loader/LevelLoader.as
@@ -160,6 +160,7 @@ package org.mangui.hls.loader {
 
         /** Load the manifest file. **/
         public function load(url : String) : void {
+			if(HLSSettings.proxyUrl) url = HLSSettings.proxyUrl + escape(url)
             if(!_urlloader) {
                 //_urlloader = new URLLoader();
                 var urlLoaderClass : Class = _hls.URLloader as Class;

--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -11,7 +11,7 @@ package org.mangui.hls.playlist {
     import flash.utils.ByteArray;
     import flash.utils.Dictionary;
     import flash.utils.getTimer;
-	import org.mangui.hls.HLSSettings;
+    import org.mangui.hls.HLSSettings;
     
     import org.mangui.hls.HLS;
     import org.mangui.hls.constant.HLSLoaderTypes;
@@ -506,7 +506,7 @@ package org.mangui.hls.playlist {
 
         /** Extract URL (check if absolute or not). **/
         private static function _extractURL(path : String, base : String) : String {
-			if (HLSSettings.proxyUrl && base.indexOf(HLSSettings.proxyUrl) != -1) base = unescape(base.split(HLSSettings.proxyUrl)[1]);
+            if (HLSSettings.proxyUrl && base.indexOf(HLSSettings.proxyUrl) != -1) base = unescape(base.split(HLSSettings.proxyUrl)[1]);
             var _prefix : String = null;
             var _suffix : String = null;
             // trim white space if any

--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -270,6 +270,7 @@ package org.mangui.hls.playlist {
                     tag_list.push(line);
                 } else if (extinf_found == true) {
                     var url : String = _extractURL(line, base);
+					trace( "url : " + url );
                     var fragment_decrypt_iv : ByteArray;
                     if (decrypt_url != null) {
                         /* as per HLS spec :
@@ -506,13 +507,14 @@ package org.mangui.hls.playlist {
 
         /** Extract URL (check if absolute or not). **/
         private static function _extractURL(path : String, base : String) : String {
-            if (HLSSettings.proxyUrl && base.indexOf(HLSSettings.proxyUrl) != -1) base = unescape(base.split(HLSSettings.proxyUrl)[1]);
+            if (HLSSettings.proxyUrl && HLSSettings.useProxyForFragments && base.indexOf(HLSSettings.proxyUrl) != -1) base = unescape(base.split(HLSSettings.proxyUrl)[1]);
+            var _returnUrl:String;
             var _prefix : String = null;
             var _suffix : String = null;
             // trim white space if any
             path.replace(replacespace, "");
             if (path.substr(0, 7) == 'http://' || path.substr(0, 8) == 'https://') {
-                return path;
+                return (HLSSettings.proxyUrl && HLSSettings.useProxyForFragments)?HLSSettings.proxyUrl+path:path;
             } else {
                 // Remove querystring
                 if (base.indexOf('?') > -1) {
@@ -525,14 +527,17 @@ package org.mangui.hls.playlist {
                     // suffix = domain/subdomain:1234/otherstuff
                     _prefix = base.substr(0, base.indexOf("//") + 2);
                     _suffix = base.substr(base.indexOf("//") + 2);
-                    if(path.charAt(1) == '/') {
-                            return _prefix + path.substr(2);
+                    if (path.charAt(1) == '/') {
+                            _returnUrl = _prefix + path.substr(2);
+                            return (HLSSettings.proxyUrl && HLSSettings.useProxyForFragments)?HLSSettings.proxyUrl+_returnUrl:_returnUrl;
                         } else {
                             // return http[s]://domain/subdomain:1234/path
-                            return _prefix + _suffix.substr(0, _suffix.indexOf("/")) + path;
+                            _returnUrl = _prefix + _suffix.substr(0, _suffix.indexOf("/")) + path
+                            return (HLSSettings.proxyUrl && HLSSettings.useProxyForFragments)?HLSSettings.proxyUrl + _returnUrl:_returnUrl;
                         }
                 } else {
-                    return base.substr(0, base.lastIndexOf('/') + 1) + path;
+                    _returnUrl = base.substr(0, base.lastIndexOf('/') + 1) + path
+                    return (HLSSettings.proxyUrl && HLSSettings.useProxyForFragments)?HLSSettings.proxyUrl + _returnUrl:_returnUrl;
                 }
             }
         };

--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -11,6 +11,7 @@ package org.mangui.hls.playlist {
     import flash.utils.ByteArray;
     import flash.utils.Dictionary;
     import flash.utils.getTimer;
+	import org.mangui.hls.HLSSettings;
     
     import org.mangui.hls.HLS;
     import org.mangui.hls.constant.HLSLoaderTypes;
@@ -505,6 +506,7 @@ package org.mangui.hls.playlist {
 
         /** Extract URL (check if absolute or not). **/
         private static function _extractURL(path : String, base : String) : String {
+			if (HLSSettings.proxyUrl && base.indexOf(HLSSettings.proxyUrl) != -1) base = unescape(base.split(HLSSettings.proxyUrl)[1]);
             var _prefix : String = null;
             var _suffix : String = null;
             // trim white space if any


### PR DESCRIPTION
I needed this to avoid crossdomain.xml refusal. 

These changes to flashls plus https://github.com/cowboy/php-simple-proxy and a permissive crossdomain.xml on my own server allows for the playing of content otherwise not allowed by crossdomain policies.

Offered in case it's of interest.
