### PR TITLE
Surface EXT-X-STREAM-INF's CLOSED_CAPTIONS=NONE

### DIFF
--- a/src/org/mangui/hls/model/Level.as
+++ b/src/org/mangui/hls/model/Level.as
@@ -19,6 +19,8 @@ package org.mangui.hls.model {
         public var codec_h264 : Boolean;
         /** Level Bitrate. **/
         public var bitrate : uint;
+        /** captions . **/
+        public var closed_captions : String;
         /** Level Name. **/
         public var name : String;
         /** level index (sorted by bitrate) **/

--- a/src/org/mangui/hls/playlist/Manifest.as
+++ b/src/org/mangui/hls/playlist/Manifest.as
@@ -344,6 +344,8 @@ package org.mangui.hls.playlist {
                             }
                         } else if (param.indexOf('AUDIO') > -1) {
                             level.audio_stream_id = (param.split('=')[1] as String).replace(replacedoublequote, "").replace(trimwhitespace, "");
+                        } else if (param.indexOf('CLOSED-CAPTIONS') > -1) {
+                            level.closed_captions = (param.split('=')[1] as String).replace(replacedoublequote, "").replace(trimwhitespace, "");
                         } else if (param.indexOf('NAME') > -1) {
                             level.name = (param.split('=')[1] as String).replace(replacedoublequote, "");
                         }

--- a/src/org/mangui/osmf/plugins/HLSMediaElement.as
+++ b/src/org/mangui/osmf/plugins/HLSMediaElement.as
@@ -127,6 +127,9 @@
             var audioTrait : AudioTrait = new NetStreamAudioTrait(_stream);
             addTrait(MediaTraitType.AUDIO, audioTrait);
 
+            var ccTrait : HLSClosedCaptionsTrait = new HLSClosedCaptionsTrait(_hls);
+            addTrait(HLSMediaTraitType.CLOSED_CAPTIONS, ccTrait);
+
             var bufferTrait : BufferTrait = new HLSBufferTrait(_hls);
             addTrait(MediaTraitType.BUFFER, bufferTrait);
 

--- a/src/org/mangui/osmf/plugins/traits/HLSClosedCaptionsState.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSClosedCaptionsState.as
@@ -1,0 +1,9 @@
+package org.mangui.osmf.plugins.traits
+{
+	public final class HLSClosedCaptionsState
+	{
+		public static const YES:String	= "yes";
+		public static const NO:String	= "no";
+		public static const UNKNOWN:String	= "unknown";
+	}
+}

--- a/src/org/mangui/osmf/plugins/traits/HLSClosedCaptionsTrait.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSClosedCaptionsTrait.as
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ package org.mangui.osmf.plugins.traits {
+    import org.mangui.hls.HLS;
+    import org.mangui.hls.event.HLSEvent;
+    import org.mangui.hls.model.Level;
+    import org.osmf.traits.MediaTraitBase;
+
+    CONFIG::LOGGING {
+    import org.mangui.hls.utils.Log;
+    }
+
+    public class HLSClosedCaptionsTrait extends MediaTraitBase {
+        private var _hls : HLS;
+        private var _hasClosedCapations : String;
+
+        public function HLSClosedCaptionsTrait(hls : HLS, closed_captions : String = HLSClosedCaptionsState.UNKNOWN) {
+            CONFIG::LOGGING {
+            Log.debug("HLSClosedCaptionsTrait()");
+            }
+            super(HLSMediaTraitType.CLOSED_CAPTIONS);
+
+			_hasClosedCapations = closed_captions;
+            _hls = hls;
+            _hls.addEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
+        }
+
+        override public function dispose() : void {
+            CONFIG::LOGGING {
+            Log.debug("HLSClosedCaptionsTrait:dispose");
+            }
+            _hls.removeEventListener(HLSEvent.LEVEL_SWITCH, _levelSwitchHandler);
+            super.dispose();
+        }
+
+        public function hasClosedCaptions() : String {
+        	return _hasClosedCapations;
+        }
+
+        /** Update playback position/duration **/
+        private function _levelSwitchHandler(event : HLSEvent) : void {
+        	var cc : String = (_hls.levels[event.level] as Level).closed_captions;
+
+        	if (cc && cc === "NONE")
+        	{
+        		// manifest told us to ignore any 608/708 binary
+        		_hasClosedCapations = HLSClosedCaptionsState.NO;
+        	}
+    		else
+    		{
+    			_hasClosedCapations = HLSClosedCaptionsState.UNKNOWN;
+    		}
+
+    		// YES only happens for WebVTT, which isn't supported.
+        }
+    }
+}

--- a/src/org/mangui/osmf/plugins/traits/HLSMediaTraitType.as
+++ b/src/org/mangui/osmf/plugins/traits/HLSMediaTraitType.as
@@ -1,0 +1,7 @@
+package org.mangui.osmf.plugins.traits
+{
+	public final class HLSMediaTraitType
+	{
+		public static const CLOSED_CAPTIONS:String	= "hlsClosedCaptions";
+	}
+}


### PR DESCRIPTION
Added parsing for EXT-X-STREAM-INF's CLOSED_CAPTIONS parameter and an
OSMF trait to make it easy to inspect

This enables consumers of flashls to decide whether the onCaptionInfo messages contain captions or just empty junk.
