### PR TITLE
ChromelessPlayer: Listen and trigger endlist-event

### DIFF
--- a/src/org/mangui/chromeless/ChromelessPlayer.as
+++ b/src/org/mangui/chromeless/ChromelessPlayer.as
@@ -170,6 +170,10 @@ package org.mangui.chromeless {
             _trigger("levelLoaded", event.loadMetrics);
         };
 
+        protected function _levelEndlistHandler(event : HLSEvent) : void {
+            _trigger("levelEndlist", event.level);
+        };
+
         protected function _audioLevelLoadedHandler(event : HLSEvent) : void {
             _trigger("audioLevelLoaded", event.loadMetrics);
         };
@@ -503,6 +507,7 @@ package org.mangui.chromeless {
             _hls.addEventListener(HLSEvent.FRAGMENT_LOADED, _fragmentLoadedHandler);
             _hls.addEventListener(HLSEvent.AUDIO_LEVEL_LOADED, _audioLevelLoadedHandler);
             _hls.addEventListener(HLSEvent.LEVEL_LOADED, _levelLoadedHandler);
+            _hls.addEventListener(HLSEvent.LEVEL_ENDLIST, _levelEndlistHandler);
             _hls.addEventListener(HLSEvent.FRAGMENT_PLAYING, _fragmentPlayingHandler);
             _hls.addEventListener(HLSEvent.MANIFEST_LOADED, _manifestLoadedHandler);
             _hls.addEventListener(HLSEvent.MEDIA_TIME, _mediaTimeHandler);

--- a/src/org/mangui/hls/event/HLSEvent.as
+++ b/src/org/mangui/hls/event/HLSEvent.as
@@ -137,6 +137,7 @@ package org.mangui.hls.event {
                 case LEVEL_LOADING:
                 case LEVEL_LOADING_ABORTED:
                 case LEVEL_SWITCH:
+                case LEVEL_ENDLIST:
                 case AUDIO_LEVEL_LOADING:
                 case FPS_DROP:
                 case FPS_DROP_LEVEL_CAPPING:


### PR DESCRIPTION
Endlist-event is needed that clappr is able to update its playback type.
See: https://github.com/jussike/clappr/commit/1103fc4f7f484041f4e4b5204735596b24fc6851
