### PR TITLE
flashls issue#526 -- provide external interface callback for live loading stalled event

### DIFF
--- a/build/build_chromeless.sh
+++ b/build/build_chromeless.sh
@@ -7,21 +7,32 @@ fi
 OPT_DEBUG="-use-network=false \
     -optimize=true \
     -debug=true \
+    -library-path+=../lib/blooddy_crypto.swc \
     -define=CONFIG::LOGGING,true \
     -define=CONFIG::FLASH_11_1,true"
 
 OPT_RELEASE="-use-network=false \
     -optimize=true \
     -debug=false \
+    -library-path+=../lib/blooddy_crypto.swc \
     -define=CONFIG::LOGGING,false \
     -define=CONFIG::FLASH_11_1,true"
+
+echo "Compiling bin/release/flashlsChromeless.swf"
+$FLEXPATH/bin/mxmlc ../src/org/mangui/chromeless/ChromelessPlayer.as \
+    -source-path ../src \
+    -o ../bin/release/flashlsChromeless.swf \
+    $OPT_RELEASE \
+    -target-player="11.1" \
+    -default-size 480 270 \
+    -default-background-color=0x000000
+./add-opt-in.py ../bin/release/flashlsChromeless.swf
 
 echo "Compiling bin/debug/flashlsChromeless.swf"
 $FLEXPATH/bin/mxmlc ../src/org/mangui/chromeless/ChromelessPlayer.as \
     -source-path ../src \
     -o ../bin/debug/flashlsChromeless.swf \
     $OPT_DEBUG \
-    -library-path+=../lib/blooddy_crypto.swc \
     -target-player="11.1" \
     -default-size 480 270 \
     -default-background-color=0x000000

--- a/src/org/mangui/chromeless/ChromelessPlayer.as
+++ b/src/org/mangui/chromeless/ChromelessPlayer.as
@@ -251,6 +251,10 @@ package org.mangui.chromeless {
             _trigger("id3Updated", event.ID3Data);
         }
 
+        protected function _liveLoadingStalledHandler(event : HLSEvent) : void {
+            _trigger("liveLoadingStalled");
+        };
+
         /** Javascript getters. **/
         protected function _getCurrentLevel() : int {
             return _hls.currentLevel;
@@ -520,10 +524,11 @@ package org.mangui.chromeless {
             _hls.addEventListener(HLSEvent.FPS_DROP, _fpsDropHandler);
             _hls.addEventListener(HLSEvent.FPS_DROP_LEVEL_CAPPING, _fpsDropLevelCappingHandler);
             _hls.addEventListener(HLSEvent.FPS_DROP_SMOOTH_LEVEL_SWITCH, _fpsDropSmoothLevelSwitchHandler);
+            _hls.addEventListener(HLSEvent.LIVE_LOADING_STALLED, _liveLoadingStalledHandler);
 
             if (available && stage.stageVideos.length > 0) {
                 _stageVideo = stage.stageVideos[0];
-                _stageVideo.addEventListener(StageVideoEvent.RENDER_STATE, _onStageVideoStateChange)
+                _stageVideo.addEventListener(StageVideoEvent.RENDER_STATE, _onStageVideoStateChange);
                 _stageVideo.viewPort = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
                 _stageVideo.attachNetStream(_hls.stream);
             } else {


### PR DESCRIPTION
As a workaround for complete player freeze after this event. Also `build/build_chromeless.sh` update (will build debug and release versions of chromeless now). 
