### PR TITLE
In AS3, coercing any string with a length > 0 always returns true.

### DIFF
--- a/src/org/mangui/hls/utils/Params2Settings.as
+++ b/src/org/mangui/hls/utils/Params2Settings.as
@@ -54,8 +54,14 @@
                     var cName : String = getQualifiedClassName(HLSSettings[param]);
                     // AS3 bug: "getDefinitionByName" considers var value, not type, and wrongly (e.g. 3.0 >> "int"; 3.1 >> "Number").
                     var c : Class = cName === "int" ? Number : getDefinitionByName(cName) as Class;
-                    // get HLSSetting type
-                    HLSSettings[param] = c(value);
+                    
+                    // only set booleans to true if the string actually is true, otherwise false
+                    if(cName === "Boolean") {
+                        HLSSettings[param] = String(value).toLowerCase() === "true";
+                    } else { // Otherwise just cast it
+                        HLSSettings[param] = c(value);
+                    }
+
                     CONFIG::LOGGING {
                         Log.info("HLSSettings." + param + " = " + HLSSettings[param]);
                     }


### PR DESCRIPTION
For example "false" returns true, this was causing issues when the passing in Params from an outside source.  The only way to pass false previously would be to pass an empty string.
