### PR TITLE
Try other levels when encountering cross domain errors

### DIFF
--- a/src/org/mangui/hls/loader/LevelLoader.as
+++ b/src/org/mangui/hls/loader/LevelLoader.as
@@ -87,10 +87,7 @@ package org.mangui.hls.loader {
         private function _errorHandler(event : ErrorEvent) : void {
             var txt : String = "Cannot load M3U8: " + event.text;
             var code : int = HLSError.MANIFEST_LOADING_IO_ERROR;
-            if (event is SecurityErrorEvent) {
-                code = HLSError.MANIFEST_LOADING_CROSSDOMAIN_ERROR;
-                txt = "Cannot load M3U8: crossdomain access denied:" + event.text;
-            } else if (event is IOErrorEvent && (HLSSettings.manifestLoadMaxRetry == -1 || _retryCount < HLSSettings.manifestLoadMaxRetry)) {
+            if (event is IOErrorEvent && (HLSSettings.manifestLoadMaxRetry == -1 || _retryCount < HLSSettings.manifestLoadMaxRetry)) {
                 CONFIG::LOGGING {
                     Log.warn("I/O Error while trying to load Playlist, retry in " + _retryTimeout + " ms");
                 }
@@ -105,6 +102,10 @@ package org.mangui.hls.loader {
                 dispatchHLSEvent(HLSEvent.WARNING,code, txt);
                 return;
             } else {
+                if (event is SecurityErrorEvent) {
+                    code = HLSError.MANIFEST_LOADING_CROSSDOMAIN_ERROR;
+                    txt = "Cannot load M3U8: crossdomain access denied:" + event.text;
+                }
                 // if we have redundant streams left for that level, switch to it, otherwise retry primary stream
                 if(_loadLevel < _levels.length && _levels[_loadLevel].redundantStreamsNb>0 ) {
                     CONFIG::LOGGING {


### PR DESCRIPTION
This is relevant to support primary / backup scenarios.

When the primary source is unreachable, Flash will not be able to retrieve its crossdomain.xml and hence raise a security error.
This change treats a security error like any other loading error and skips to the next level.

Sample playlist which fails to play back in current flashls-0.4.4.24: http://assets-dev-clf-aws-eu-west-1.slidesync.com/public/debugging/flashls-crossdomain/flashls-crossdomain.m3u8